### PR TITLE
fix: make json in blocking not async

### DIFF
--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -58,7 +58,7 @@ impl Response {
     /// returned.
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-    pub async fn json<T: serde::de::DeserializeOwned>(self) -> crate::Result<T> {
+    pub fn json<T: serde::de::DeserializeOwned>(self) -> crate::Result<T> {
         Ok(serde_json::from_slice(&self.bytes()?)?)
     }
 


### PR DESCRIPTION
This pull request modifies the `Response` implementation in `src/blocking/response.rs` to make the `json` method synchronous, aligning it with the blocking nature of the module.

Key change:

* Changed the `json` method in `impl Response` from asynchronous (`async fn`) to synchronous (`fn`) to better reflect the blocking behavior of the `Response` module. This ensures consistency in the API for blocking operations. (`[src/blocking/response.rsL61-R61](diffhunk://#diff-12f8632e96ca0948c910ae6031df58df4e79e30015dda690c2b4be81637b069cL61-R61)`)

* Closes https://github.com/bdbai/nyquest/issues/2