### PR TITLE
lib/feat: Status Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "nyquest-backend-curl",
  "nyquest-backend-nsurlsession",
  "nyquest-backend-winrt",
+ "serde",
  "tokio",
 ]
 

--- a/nyquest-backend-tests/Cargo.toml
+++ b/nyquest-backend-tests/Cargo.toml
@@ -33,7 +33,7 @@ curl = ["dep:nyquest-backend-curl"]
 nsurlsession = ["dep:nyquest-backend-nsurlsession"]
 
 [dev-dependencies]
-nyquest = { path = "../" }
+nyquest = { path = "../", features = ["json"] }
 hyper = { version = "1", features = ["http1", "client"] }
 tokio = { version = "1", features = ["full"] }
 http-body-util = "0.1"
@@ -42,6 +42,7 @@ form_urlencoded = "1"
 memchr = "2"
 multer = "3"
 futures = "0.3"
+serde = { version = "1", features = ["derive"] }
 cfg-if.workspace = true
 
 [dependencies]

--- a/nyquest-backend-tests/src/fixtures.rs
+++ b/nyquest-backend-tests/src/fixtures.rs
@@ -1,4 +1,5 @@
 mod client_options;
+mod errors;
 mod requests;
 mod responses;
 mod scenarios;

--- a/nyquest-backend-tests/src/fixtures/errors.rs
+++ b/nyquest-backend-tests/src/fixtures/errors.rs
@@ -1,0 +1,2 @@
+mod invalid_json;
+mod unsuccessful_status;

--- a/nyquest-backend-tests/src/fixtures/errors/invalid_json.rs
+++ b/nyquest-backend-tests/src/fixtures/errors/invalid_json.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod tests {
+    use http_body_util::Full;
+    use hyper::header::CONTENT_TYPE;
+    use nyquest::{Error, Request as NyquestRequest};
+
+    use crate::*;
+
+    #[test]
+    fn test_json_deserialization_error() {
+        const PATH: &str = "errors/invalid_json_response";
+        const INVALID_JSON: &str = r#"{"name": "Test User", "age": 30, invalid_json}"#;
+
+        let _handle = crate::add_hyper_fixture(PATH, |_| async move {
+            let res = Response::builder()
+                .header(CONTENT_TYPE, "application/json")
+                .body(Full::new(Bytes::from(INVALID_JSON)))
+                .unwrap();
+            (res, Ok(()))
+        });
+
+        #[allow(unused)]
+        #[derive(serde::Deserialize, Debug)]
+        struct User {
+            name: String,
+            age: u32,
+        }
+
+        let builder = crate::init_builder_blocking().unwrap();
+
+        #[cfg(feature = "blocking")]
+        {
+            let client = builder.clone().build_blocking().unwrap();
+            let err = client
+                .request(NyquestRequest::get(PATH))
+                .unwrap()
+                .json::<User>()
+                .unwrap_err();
+
+            assert!(matches!(err, Error::Json(_)));
+        }
+
+        #[cfg(feature = "async")]
+        {
+            let err = TOKIO_RT.block_on(async {
+                let client = builder.build_async().await.unwrap();
+                client
+                    .request(NyquestRequest::get(PATH))
+                    .await
+                    .unwrap()
+                    .json::<User>()
+                    .await
+                    .unwrap_err()
+            });
+
+            assert!(matches!(err, Error::Json(_)));
+        }
+    }
+}

--- a/nyquest-backend-tests/src/fixtures/errors/unsuccessful_status.rs
+++ b/nyquest-backend-tests/src/fixtures/errors/unsuccessful_status.rs
@@ -1,0 +1,191 @@
+#[cfg(test)]
+mod tests {
+    use http_body_util::Full;
+    use hyper::{Method, StatusCode};
+    use nyquest::{Error, Request as NyquestRequest};
+
+    use crate::*;
+
+    #[test]
+    fn test_unsuccessful_status_codes() {
+        const PATH: &str = "errors/unsuccessful_status_codes";
+
+        let _handle = crate::add_hyper_fixture(PATH, |req| async move {
+            let mut res = Response::builder();
+
+            if req.method() == Method::GET {
+                res = res.status(StatusCode::BAD_REQUEST);
+            } else if req.method() == Method::POST {
+                res = res.status(StatusCode::NOT_FOUND);
+            } else if req.method() == Method::PUT {
+                res = res.status(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+
+            let response = res.body(Full::new(Bytes::from("Error response"))).unwrap();
+            (response, Ok(()))
+        });
+
+        let builder = crate::init_builder_blocking().unwrap();
+
+        let assertions = |status_code: u16, error: Error| match error {
+            Error::NonSuccessfulStatusCode(received_status) => {
+                assert_eq!(received_status, status_code);
+            }
+            _ => panic!("Expected NonSuccessfulStatusCode error, got: {:?}", error),
+        };
+
+        #[cfg(feature = "blocking")]
+        {
+            let client = builder.clone().build_blocking().unwrap();
+
+            // Test GET request (400 Bad Request)
+            let err = client
+                .request(NyquestRequest::get(PATH))
+                .unwrap()
+                .with_successful_status()
+                .unwrap_err();
+            assertions(400, err);
+
+            // Test POST request (404 Not Found)
+            let err = client
+                .request(NyquestRequest::post(PATH))
+                .unwrap()
+                .with_successful_status()
+                .unwrap_err();
+            assertions(404, err);
+
+            // Test PUT request (500 Internal Server Error)
+            let err = client
+                .request(NyquestRequest::put(PATH))
+                .unwrap()
+                .with_successful_status()
+                .unwrap_err();
+            assertions(500, err);
+        }
+
+        #[cfg(feature = "async")]
+        {
+            TOKIO_RT.block_on(async {
+                let client = builder.build_async().await.unwrap();
+
+                // Test GET request (400 Bad Request)
+                let err = client
+                    .request(NyquestRequest::get(PATH))
+                    .await
+                    .unwrap()
+                    .with_successful_status()
+                    .unwrap_err();
+                assertions(400, err);
+
+                // Test POST request (404 Not Found)
+                let err = client
+                    .request(NyquestRequest::post(PATH))
+                    .await
+                    .unwrap()
+                    .with_successful_status()
+                    .unwrap_err();
+                assertions(404, err);
+
+                // Test PUT request (500 Internal Server Error)
+                let err = client
+                    .request(NyquestRequest::put(PATH))
+                    .await
+                    .unwrap()
+                    .with_successful_status()
+                    .unwrap_err();
+                assertions(500, err);
+            });
+        }
+    }
+
+    #[test]
+    fn test_successful_status_codes() {
+        const PATH: &str = "errors/successful_status_codes";
+
+        let _handle = crate::add_hyper_fixture(PATH, |req| async move {
+            let mut res = Response::builder();
+
+            if req.method() == Method::GET {
+                res = res.status(StatusCode::OK);
+            } else if req.method() == Method::POST {
+                res = res.status(StatusCode::CREATED);
+            } else if req.method() == Method::PUT {
+                res = res.status(StatusCode::NO_CONTENT);
+            }
+
+            let response = res
+                .body(Full::new(Bytes::from("Success response")))
+                .unwrap();
+            (response, Ok(()))
+        });
+
+        let builder = crate::init_builder_blocking().unwrap();
+
+        let assertions = |status_code: u16| {
+            assert!(status_code >= 200 && status_code < 300);
+        };
+
+        #[cfg(feature = "blocking")]
+        {
+            let client = builder.clone().build_blocking().unwrap();
+
+            // Test GET request (200 OK)
+            let response = client
+                .request(NyquestRequest::get(PATH))
+                .unwrap()
+                .with_successful_status()
+                .unwrap();
+            assertions(response.status().into());
+
+            // Test POST request (201 Created)
+            let response = client
+                .request(NyquestRequest::post(PATH))
+                .unwrap()
+                .with_successful_status()
+                .unwrap();
+            assertions(response.status().into());
+
+            // Test PUT request (204 No Content)
+            let response = client
+                .request(NyquestRequest::put(PATH))
+                .unwrap()
+                .with_successful_status()
+                .unwrap();
+            assertions(response.status().into());
+        }
+
+        #[cfg(feature = "async")]
+        {
+            TOKIO_RT.block_on(async {
+                let client = builder.build_async().await.unwrap();
+
+                // Test GET request (200 OK)
+                let response = client
+                    .request(NyquestRequest::get(PATH))
+                    .await
+                    .unwrap()
+                    .with_successful_status()
+                    .unwrap();
+                assertions(response.status().into());
+
+                // Test POST request (201 Created)
+                let response = client
+                    .request(NyquestRequest::post(PATH))
+                    .await
+                    .unwrap()
+                    .with_successful_status()
+                    .unwrap();
+                assertions(response.status().into());
+
+                // Test PUT request (204 No Content)
+                let response = client
+                    .request(NyquestRequest::put(PATH))
+                    .await
+                    .unwrap()
+                    .with_successful_status()
+                    .unwrap();
+                assertions(response.status().into());
+            });
+        }
+    }
+}

--- a/nyquest-backend-tests/src/fixtures/responses.rs
+++ b/nyquest-backend-tests/src/fixtures/responses.rs
@@ -27,7 +27,11 @@ mod tests {
         #[cfg(feature = "blocking")]
         {
             let client = builder.clone().build_blocking().unwrap();
-            let res = client.request(NyquestRequest::get(PATH)).unwrap();
+            let res = client
+                .request(NyquestRequest::get(PATH))
+                .unwrap()
+                .with_successful_status()
+                .unwrap();
             let status = res.status();
             let content_len = res.content_length();
             let content = res.text().unwrap();
@@ -37,7 +41,12 @@ mod tests {
         {
             let facts = TOKIO_RT.block_on(async {
                 let client = builder.build_async().await.unwrap();
-                let res = client.request(NyquestRequest::get(PATH)).await.unwrap();
+                let res = client
+                    .request(NyquestRequest::get(PATH))
+                    .await
+                    .unwrap()
+                    .with_successful_status()
+                    .unwrap();
                 let status = res.status();
                 let content_len = res.content_length();
                 (status.into(), content_len, res.text().await.unwrap())

--- a/nyquest-backend-tests/src/fixtures/responses.rs
+++ b/nyquest-backend-tests/src/fixtures/responses.rs
@@ -31,7 +31,7 @@ mod tests {
             let status = res.status();
             let content_len = res.content_length();
             let content = res.text().unwrap();
-            assertions((status, content_len, content));
+            assertions((status.into(), content_len, content));
         }
         #[cfg(feature = "async")]
         {
@@ -40,7 +40,7 @@ mod tests {
                 let res = client.request(NyquestRequest::get(PATH)).await.unwrap();
                 let status = res.status();
                 let content_len = res.content_length();
-                (status, content_len, res.text().await.unwrap())
+                (status.into(), content_len, res.text().await.unwrap())
             });
             assertions(facts);
         }
@@ -67,7 +67,7 @@ mod tests {
             let status = res.status();
             let content_len = res.content_length();
             let content = res.bytes().unwrap();
-            assertions((status, content_len, content));
+            assertions((status.into(), content_len, content));
         }
         #[cfg(feature = "async")]
         {
@@ -76,7 +76,7 @@ mod tests {
                 let res = client.request(NyquestRequest::get(PATH)).await.unwrap();
                 let status = res.status();
                 let content_len = res.content_length();
-                (status, content_len, res.bytes().await.unwrap())
+                (status.into(), content_len, res.bytes().await.unwrap())
             });
             assertions(facts);
         }
@@ -117,7 +117,7 @@ mod tests {
                 let request = NyquestRequest::post(PATH)
                     .with_body(NyquestBlockingBody::text(body_text.clone(), request_mime));
                 let res = blocking_client.request(request).unwrap();
-                let status = res.status();
+                let status = res.status().into();
                 assertions(status);
             }
             #[cfg(feature = "async")]
@@ -127,7 +127,7 @@ mod tests {
                 let status = TOKIO_RT.block_on(async {
                     let res = async_client.request(request).await.unwrap();
                     let status = res.status();
-                    status
+                    status.into()
                 });
                 assertions(status);
             }

--- a/src/async/response.rs
+++ b/src/async/response.rs
@@ -2,6 +2,8 @@ use std::fmt::Debug;
 
 use nyquest_interface::r#async::AnyAsyncResponse;
 
+use crate::StatusCode;
+
 /// An async HTTP response.
 pub struct Response {
     inner: Box<dyn AnyAsyncResponse>,
@@ -9,8 +11,8 @@ pub struct Response {
 
 impl Response {
     /// Get the `StatusCode` of this Response.
-    pub fn status(&self) -> u16 {
-        self.inner.status()
+    pub fn status(&self) -> StatusCode {
+        self.inner.status().into()
     }
 
     /// Get the `content-length` of this response, if known by the backend.

--- a/src/async/response.rs
+++ b/src/async/response.rs
@@ -15,6 +15,18 @@ impl Response {
         self.inner.status().into()
     }
 
+    /// Return the response as-is, or [`crate::Error::NonSuccessfulStatusCode`] if the status code
+    /// does not indicate success.
+    #[inline]
+    pub fn with_successful_status(self) -> crate::Result<Self> {
+        let status = self.status();
+        if status.is_successful() {
+            Ok(self)
+        } else {
+            Err(crate::Error::NonSuccessfulStatusCode(status))
+        }
+    }
+
     /// Get the `content-length` of this response, if known by the backend.
     pub fn content_length(&self) -> Option<u64> {
         self.inner.content_length()

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -2,6 +2,8 @@ use std::{fmt::Debug, io};
 
 use nyquest_interface::blocking::AnyBlockingResponse;
 
+use crate::StatusCode;
+
 /// A blocking HTTP response.
 pub struct Response {
     inner: Box<dyn AnyBlockingResponse>,
@@ -9,8 +11,8 @@ pub struct Response {
 
 impl Response {
     /// Get the `StatusCode` of this Response.
-    pub fn status(&self) -> u16 {
-        self.inner.status()
+    pub fn status(&self) -> StatusCode {
+        self.inner.status().into()
     }
 
     /// Get the `content-length` of this response, if known by the backend.

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -15,6 +15,18 @@ impl Response {
         self.inner.status().into()
     }
 
+    /// Return the response as-is, or [`crate::Error::NonSuccessfulStatusCode`] if the status code
+    /// does not indicate success.
+    #[inline]
+    pub fn with_successful_status(self) -> crate::Result<Self> {
+        let status = self.status();
+        if status.is_successful() {
+            Ok(self)
+        } else {
+            Err(crate::Error::NonSuccessfulStatusCode(status))
+        }
+    }
+
     /// Get the `content-length` of this response, if known by the backend.
     pub fn content_length(&self) -> Option<u64> {
         self.inner.content_length()

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,10 @@ use thiserror::Error;
 
 use nyquest_interface::Error as ErrorImpl;
 
+use crate::StatusCode;
+
 /// The errors produced by the backend.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
     /// The backend does not recognize the input as a valid URL.
@@ -24,6 +27,10 @@ pub enum Error {
     /// [`crate::ClientBuilder::request_timeout`].
     #[error("Request is not finished within timeout")]
     RequestTimeout,
+    /// The response has a non-successful status code and being checked by `with_successful_status`
+    /// method.
+    #[error("Non-successful status code: {0}")]
+    NonSuccessfulStatusCode(StatusCode),
 }
 
 /// A `Result` alias where the `Err` case is [`crate::Error`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub mod r#async;
 pub mod blocking;
 pub mod client;
 pub mod header;
+mod status;
 
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
@@ -141,3 +142,4 @@ pub use error::{Error, Result};
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub use r#async::client::AsyncClient;
 pub use request::{Method, Request};
+pub use status::StatusCode;

--- a/src/status.rs
+++ b/src/status.rs
@@ -42,10 +42,10 @@ impl StatusCode {
         400 <= self.0 && self.0 < 500
     }
 
-    /// Check if status is within 500-599 or invalid.
+    /// Check if status is within 500-599.
     #[inline]
     pub const fn is_server_error(&self) -> bool {
-        self.0 >= 500 || self.0 < 100
+        500 <= self.0 && self.0 < 600
     }
 
     /// Check if status is outside the range of 100-599.
@@ -127,7 +127,7 @@ mod tests {
         assert_eq!(status.code(), 600);
         assert!(!status.is_successful());
         assert!(!status.is_client_error());
-        assert!(status.is_server_error());
+        assert!(!status.is_server_error());
         assert!(status.is_invalid());
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,150 @@
+use std::fmt;
+
+/// HTTP status code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct StatusCode(u16);
+
+impl StatusCode {
+    /// Create a new status code.
+    #[inline]
+    pub const fn new(code: u16) -> Self {
+        Self(code)
+    }
+
+    /// Get the status code as a u16 value.
+    #[inline]
+    pub const fn code(self) -> u16 {
+        self.0
+    }
+
+    /// Check if status is within 100-199.
+    #[inline]
+    pub const fn is_informational(&self) -> bool {
+        100 <= self.0 && self.0 < 200
+    }
+
+    /// Check if status is within 200-299.
+    #[inline]
+    pub const fn is_successful(&self) -> bool {
+        200 <= self.0 && self.0 < 300
+    }
+
+    /// Check if status is within 300-399.
+    #[inline]
+    pub const fn is_redirection(&self) -> bool {
+        300 <= self.0 && self.0 < 400
+    }
+
+    /// Check if status is within 400-499.
+    #[inline]
+    pub const fn is_client_error(&self) -> bool {
+        400 <= self.0 && self.0 < 500
+    }
+
+    /// Check if status is within 500-599 or invalid.
+    #[inline]
+    pub const fn is_server_error(&self) -> bool {
+        self.0 >= 500 || self.0 < 100
+    }
+
+    /// Check if status is outside the range of 100-599.
+    #[inline]
+    pub const fn is_invalid(&self) -> bool {
+        self.0 < 100 || self.0 > 599
+    }
+}
+
+impl From<u16> for StatusCode {
+    #[inline]
+    fn from(code: u16) -> Self {
+        Self::new(code)
+    }
+}
+
+impl From<StatusCode> for u16 {
+    #[inline]
+    fn from(code: StatusCode) -> Self {
+        code.0
+    }
+}
+
+impl fmt::Display for StatusCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Default for StatusCode {
+    #[inline]
+    fn default() -> Self {
+        Self::new(200)
+    }
+}
+
+impl PartialEq<u16> for StatusCode {
+    #[inline]
+    fn eq(&self, other: &u16) -> bool {
+        self.code() == *other
+    }
+}
+
+impl PartialEq<StatusCode> for u16 {
+    #[inline]
+    fn eq(&self, other: &StatusCode) -> bool {
+        *self == other.code()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_status_codes() {
+        let status = StatusCode::default();
+        assert_eq!(status.code(), 200);
+        assert!(status.is_successful());
+        assert!(!status.is_client_error());
+        assert!(!status.is_server_error());
+        assert!(!status.is_invalid());
+
+        let status = StatusCode::from(404);
+        assert_eq!(status.code(), 404);
+        assert!(!status.is_successful());
+        assert!(status.is_client_error());
+        assert!(!status.is_server_error());
+        assert!(!status.is_invalid());
+
+        let status = StatusCode::new(500);
+        assert_eq!(status.code(), 500);
+        assert!(!status.is_successful());
+        assert!(!status.is_client_error());
+        assert!(status.is_server_error());
+        assert!(!status.is_invalid());
+
+        let status = StatusCode::new(600);
+        assert_eq!(status.code(), 600);
+        assert!(!status.is_successful());
+        assert!(!status.is_client_error());
+        assert!(status.is_server_error());
+        assert!(status.is_invalid());
+    }
+
+    #[test]
+    fn test_status_code_display() {
+        let status = StatusCode::new(200);
+        assert_eq!(format!("{}", status), "200");
+    }
+
+    #[test]
+    fn test_status_code_partial_eq() {
+        let status = StatusCode::new(200);
+        assert_eq!(status, 200);
+        assert_eq!(200, status);
+
+        let status = StatusCode::new(404);
+        assert_eq!(status, 404);
+        assert_eq!(404, status);
+    }
+}


### PR DESCRIPTION
- Added `StatusCode` struct with methods for categories
- Added helper methods to check for non-successful status codes on responses
- Made `nyquest::Error` non-exhaustive
- Added an error type for non-successful status codes
- Enhanced tests for errors

Fixes #5 

@mon would you like to review this?