### PR TITLE
backend/nsurlsession: don't invalidate on drop

### DIFF
--- a/backends/nsurlsession/src/client.rs
+++ b/backends/nsurlsession/src/client.rs
@@ -155,14 +155,6 @@ impl NSUrlSessionClient {
     }
 }
 
-impl Drop for NSUrlSessionClient {
-    fn drop(&mut self) {
-        unsafe {
-            self.session.finishTasksAndInvalidate();
-        }
-    }
-}
-
 struct FormUrlEncoder(Retained<NSCharacterSet>);
 impl FormUrlEncoder {
     fn new() -> Self {


### PR DESCRIPTION
Closes #31 

This call makes other cloned client fail. Do you think it's necessary to call it? If so, I think it needs to be wrapped in `Arc`.